### PR TITLE
refactor: Use main table name with field when performing where clause…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint-kit",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "A server-side toolset for building data layers and RESTful endpoints with NodeJS",
   "author": "|M| <manicprone@gmail.com>",
   "license": "MIT",

--- a/src/actions/bookshelf/deleteItem.js
+++ b/src/actions/bookshelf/deleteItem.js
@@ -66,7 +66,7 @@ async function doLookupThenAction (joint, lookupFieldData, modelName, specFields
     const resource = await bookshelf.model(modelName).query((queryBuilder) => {
       Object.entries(lookupFieldData)
         .forEach(([fieldName, field]) => {
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, field.value, field.matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, field.value, field.matchStrategy)
         })
     }).fetch(getItemOpts)
 
@@ -107,7 +107,7 @@ async function doAction (joint, modelName, specFields, specAuth, ownerCreds, inp
           ACTION.INPUT_FIELD_MATCHING_STRATEGY_EXACT
         )
         if (hasInput) {
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, inputFields[fieldName].value, matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, inputFields[fieldName].value, matchStrategy)
         }
       })
     } // end-if (inputFields && specFields)

--- a/src/actions/bookshelf/getItem.js
+++ b/src/actions/bookshelf/getItem.js
@@ -92,9 +92,9 @@ export default async function getItem (joint, spec = {}, input = {}, output) {
           const inputValue = (hasInput)
             ? inputFields[fieldName].value
             : defaultValue
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, inputValue, matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, inputValue, matchStrategy)
         } else if (isLocked && hasDefault) {
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, defaultValue, matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, defaultValue, matchStrategy)
         }
       }) // end-specFields.forEach
     } // end-if (inputFields && specFields)

--- a/src/actions/bookshelf/getItems.js
+++ b/src/actions/bookshelf/getItems.js
@@ -23,14 +23,12 @@ export default async function getItems (joint, spec = {}, input = {}, output) {
   // Reject if model does not exist
   const model = bookshelf.model(modelName)
   if (!model) {
-    if (debug) console.log(`[JOINT] [action:getItems] The model "${modelName}" is not recognized`)
     return Promise.reject(StatusErrors.generateModelNotRecognizedError(modelName))
   }
 
   // Reject when required fields are not provided
   const requiredFieldCheck = ActionUtils.checkRequiredFields(specFields, inputFields)
   if (!requiredFieldCheck.satisfied) {
-    if (debug) console.log('[JOINT] [action:getItems] Action has missing required fields:', requiredFieldCheck.missing)
     return Promise.reject(StatusErrors.generateMissingFieldsError(requiredFieldCheck.missing))
   }
 
@@ -107,9 +105,9 @@ export default async function getItems (joint, spec = {}, input = {}, output) {
 
         if (!isLocked && (hasInput || hasDefault)) {
           const inputValue = (hasInput) ? inputFields[fieldName].value : defaultValue
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, inputValue, matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, inputValue, matchStrategy)
         } else if (isLocked && hasDefault) {
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, defaultValue, matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, defaultValue, matchStrategy)
         }
       }) // end-specFields.forEach
     } // end-if (inputFields && specFields)

--- a/src/actions/bookshelf/updateItem.js
+++ b/src/actions/bookshelf/updateItem.js
@@ -62,7 +62,7 @@ async function performUpdateItem (joint, spec = {}, input = {}, output) {
     if (trx) getItemOpts.transacting = trx
     const resource = await model.query((queryBuilder) => {
       Object.entries(lookupFieldData).forEach(([key, field]) => {
-        BookshelfUtils.appendWhereClause(queryBuilder, key, field.value, field.matchStrategy)
+        BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, key, field.value, field.matchStrategy)
       })
     }).fetch(getItemOpts)
 

--- a/src/actions/bookshelf/updateMany.js
+++ b/src/actions/bookshelf/updateMany.js
@@ -60,7 +60,7 @@ async function performUpdateMany (joint, spec = {}, input = {}, output) {
     // Get items to perform the update action...
     const resources = await model.query((queryBuilder) => {
       Object.entries(lookupFieldData).forEach(([key, field]) => {
-        BookshelfUtils.appendWhereClause(queryBuilder, key, field.value, field.matchStrategy)
+        BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, key, field.value, field.matchStrategy)
       })
     }).fetchAll({ transacting: trx })
 

--- a/src/actions/bookshelf/upsertItem.js
+++ b/src/actions/bookshelf/upsertItem.js
@@ -86,7 +86,7 @@ async function performUpsertItem (joint, spec = {}, input = {}, output) {
     const resource = await model.query((queryBuilder) => {
       Object.entries(lookupFieldData)
         .forEach(([fieldName, field]) => {
-          BookshelfUtils.appendWhereClause(queryBuilder, fieldName, field.value, field.matchStrategy)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, field.value, field.matchStrategy)
         })
     }).fetch(actionOpts)
 

--- a/src/actions/bookshelf/utils/bookshelf-utils.js
+++ b/src/actions/bookshelf/utils/bookshelf-utils.js
@@ -110,17 +110,18 @@ export function loadRelationsToItemBase (itemData, loadDirect = {}, keepAsRelati
 // Append a where query to an existing query builder, respecting the type of
 // field value and its matchStrategy.
 // -----------------------------------------------------------------------------
-export function appendWhereClause (queryBuilder, fieldName, value, matchStrategy) {
+export function appendWhereClause (joint, queryBuilder, modelName, fieldName, value, matchStrategy) {
+  const mainTableName = joint.model[modelName].prototype.tableName
   switch (matchStrategy) {
     case ACTION.INPUT_FIELD_MATCHING_STRATEGY_EXACT:
-      if (Array.isArray(value)) queryBuilder.where(fieldName, 'IN', value)
-      else queryBuilder.where(fieldName, '=', value)
+      if (Array.isArray(value)) queryBuilder.where(`${mainTableName}.${fieldName}`, 'IN', value)
+      else queryBuilder.where(`${mainTableName}.${fieldName}`, '=', value)
       break
     case ACTION.INPUT_FIELD_MATCHING_STRATEGY_CONTAINS:
       // Case insensitive LIKE query
       // Note that case-sensitivity of LIKE differs per DBMS, comparing always
       // with lowercase is potentially slower but more portable.
-      queryBuilder.whereRaw('LOWER( ?? ) LIKE ?', [fieldName, `%${value.toLowerCase()}%`])
+      queryBuilder.whereRaw('LOWER( ?? ) LIKE ?', [`${mainTableName}.${fieldName}`, `%${value.toLowerCase()}%`])
       break
     default:
       throw new Error(`Unrecognized match strategy "${matchStrategy}"`)


### PR DESCRIPTION
Including main table name with field name for appendWhereClause logic.

We can support association-level capabilities in a future release.