### PR TITLE
Feat/adv query comparisons

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,14 +30,6 @@
 
 <br />
 
-## README To Do
-
-* Add general info / overview, once jointkit.org is ready.
-
-* Add software stack info, etc.
-
-<br />
-
 ## Backlog
 
 * `ActionUtils.prepareFieldData()` could populate the default value, so that in
@@ -48,8 +40,6 @@
 * Complete `routeConfig` functional testing, using the updated db scenarios.
 
 * Replace moment with date-fns !!!
-
-* Replace promises with `async/await` (esp in tests) !!!
 
 * Remove the quotes on the modelNames in the error messages.
 
@@ -150,7 +140,7 @@ joint.method.Order.getOne({
 })
 ```
 
-We also need to be able to support performing a search operation on associations.
+We also need to be able to support performing a query operation on associations.
 
 ### Example
 

--- a/TODO.md
+++ b/TODO.md
@@ -32,10 +32,14 @@
 
 ## Backlog
 
+* Support advanced comparison logic on toMany associations.
+
 * `ActionUtils.prepareFieldData()` could populate the default value, so that in
   each DB implementation the query can be built solely by the returned input
   fields, rather than using a combination of field specs and field data, making
   the logic DRY-er.
+
+* Clean up joint-error-serializer.js (since refactor of spec operators)
 
 * Complete `routeConfig` functional testing, using the updated db scenarios.
 
@@ -110,9 +114,7 @@
 
 ## Advanced Operations
 
-Instead of the operands attribute in the spec, we just support overloaded input capabilities (via object notation).
-
-> You should not have to update the spec for these variations.
+Using object notation for input values allows for advanced querying.
 
 ### Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint-kit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A server-side toolset for building data layers and RESTful endpoints with NodeJS",
   "author": "|M| <manicprone@gmail.com>",
   "license": "MIT",

--- a/src/actions/action-utils.js
+++ b/src/actions/action-utils.js
@@ -313,12 +313,13 @@ export function prepareFieldData (fieldSpec = [], fieldData = {}) {
 
       // Perform data type cast on provided field values
       if (fieldName && objectUtils.has(fieldData, fieldName)) {
-        if (objectUtils.isPlainObject(fieldData[fieldName])) {
-          // TODO - We will need to iterate the values of the object and cast appropriately !!!
-          // TDD with unit tests
+        if (objectUtils.isPlainObject(fieldData[fieldName]) && dataType !== 'JSON') {
           // Handle advanced queries and field set values
-          // console.log('[DEVING] prepareFieldData -- ADVANCED QUERY', fieldData[fieldName])
-          preparedFieldData[fieldName] = fieldData[fieldName]
+          // console.log(`[DEVING] prepareFieldData (${dataType}) -- ADVANCED QUERY`, fieldData[fieldName])
+          preparedFieldData[fieldName] = Object.entries(fieldData[fieldName]).reduce((acc, [key, value]) => {
+            acc[key] = castValue(value, dataType)
+            return acc
+          }, {})
         } else {
           preparedFieldData[fieldName] = castValue(fieldData[fieldName], dataType)
         }
@@ -358,6 +359,7 @@ export function castValue (value, dataType) {
     case 'Number': return Number(value)
     case 'Boolean': return (isNaN(value)) ? (value.toLowerCase() == 'true') : Boolean(value) // eslint-disable-line eqeqeq
     case 'JSON': return JSON.stringify(value)
+    case 'Date': return new Date(value)
     default: return String(value)
   }
 }

--- a/src/actions/bookshelf/getItems.js
+++ b/src/actions/bookshelf/getItems.js
@@ -101,9 +101,9 @@ export default async function getItems (joint, spec = {}, input = {}, output) {
 
         if (!isLocked && (hasInput || hasDefault)) {
           const inputValue = (hasInput) ? inputFields[fieldName] : defaultValue
-          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, inputValue)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, inputValue, fieldSpec.type)
         } else if (isLocked && hasDefault) {
-          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, defaultValue)
+          BookshelfUtils.appendWhereClause(joint, queryBuilder, modelName, fieldName, defaultValue, fieldSpec.type)
         }
       }) // end-specFields.forEach
     } // end-if (inputFields && specFields)

--- a/src/actions/bookshelf/utils/bookshelf-utils.js
+++ b/src/actions/bookshelf/utils/bookshelf-utils.js
@@ -7,6 +7,13 @@ import * as CoreUtils from '../../../core/core-utils'
 const debugLoadDirect = false
 const debugAppendWhereClause = false
 
+const comparisonOperatorMap = {
+  [ACTION.INPUT_FIELD_QUERY_LESS_THAN]: '<',
+  [ACTION.INPUT_FIELD_QUERY_LESS_THAN_OR_EQUAL]: '<=',
+  [ACTION.INPUT_FIELD_QUERY_GREATER_THAN]: '>',
+  [ACTION.INPUT_FIELD_QUERY_GREATER_THAN_OR_EQUAL]: '>='
+}
+
 // -----------------------------------------------------------------------------
 // Accepts the "orderBy" API field value and returns
 // the Bookshelf-compatible specification for an order-by clause.
@@ -140,6 +147,26 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
   } else if (value !== null && typeof value === 'object') {
     if (debugAppendWhereClause) console.log(`[DEVING] WHERE CLAUSE with ADVANCED QUERY: ${mainTableName} => ${fieldName}:`, value)
 
+    // Association query logic for reusability
+    let assocJoinApplied = false
+    const ensureAssociationJoin = () => {
+      if (!isAssocClause || assocJoinApplied) return
+
+      if (!assocModelName) {
+        throw new Error(`The query argument "${assocName}.${assocField}" is invalid as the association "${assocName}" does not exist for model "${modelName}"`)
+      }
+
+      if (assocConfig.type !== 'toOne') {
+        throw new Error(`The query argument "${assocName}.${assocField}" is invalid because the association "${assocName}" is not of type "toOne".`)
+      }
+
+      queryBuilder
+        .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
+        .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
+
+      assocJoinApplied = true
+    }
+
     for (const operator of Object.keys(value)) {
       switch (operator) {
         // OPERATOR: Contains (case sensitive)
@@ -151,24 +178,16 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
           if (isAssocClause) {
             if (debugAppendWhereClause) console.log(`[DEVING] Handling "${operator}" (case sensitive) action via association field on:`, value[operator])
 
-            // TODO - Complete this with join logic !!!
+            ensureAssociationJoin()
+
             if (dialect === 'sqlite3') {
               const globValue = `*${valueForQuery}*` // use GLOB for case-sensitive matching
-              queryBuilder
-                .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
-                .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
-                .whereRaw('?? GLOB ?', [`${assocTableName}.${assocField}`, globValue])
+              queryBuilder.whereRaw('?? GLOB ?', [`${assocTableName}.${assocField}`, globValue])
             } else if (dialect === 'mysql' || dialect === 'mysql2') {
-              queryBuilder
-                .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
-                .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
-                .whereRaw('?? LIKE BINARY ?', [`${assocTableName}.${assocField}`, `%${valueForQuery}%`])
+              queryBuilder.whereRaw('?? LIKE BINARY ?', [`${assocTableName}.${assocField}`, `%${valueForQuery}%`])
             } else {
               // default: Postgres, et al - LIKE defaults to case-sensitive matching
-              queryBuilder
-                .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
-                .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
-                .whereRaw('?? LIKE ?', [`${assocTableName}.${assocField}`, `%${valueForQuery}%`])
+              queryBuilder.whereRaw('?? LIKE ?', [`${assocTableName}.${assocField}`, `%${valueForQuery}%`])
             }
 
           // Operating on a Main Resource Field
@@ -243,13 +262,6 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
         case ACTION.INPUT_FIELD_QUERY_GREATER_THAN_OR_EQUAL: {
           if (debugAppendWhereClause) console.log(`[DEVING] Handling "${operator}" action on:`, value[operator])
 
-          // Load comparison symbol
-          const comparisonOperatorMap = {
-            [ACTION.INPUT_FIELD_QUERY_LESS_THAN]: '<',
-            [ACTION.INPUT_FIELD_QUERY_LESS_THAN_OR_EQUAL]: '<=',
-            [ACTION.INPUT_FIELD_QUERY_GREATER_THAN]: '>',
-            [ACTION.INPUT_FIELD_QUERY_GREATER_THAN_OR_EQUAL]: '>='
-          }
           const comparisonSymbol = comparisonOperatorMap[operator]
 
           // Only allow comparisons on Numbers or Dates
@@ -271,26 +283,27 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
             throw new Error(`The "${operator}" operator requires a valid Date value.`)
           }
 
-          const bindingValue = (dataType === 'Date') ? valueForQuery.toISOString() : valueForQuery
+          const isDateComparison = dataType === 'Date'
+          const applyComparison = (columnRef) => {
+            if (isDateComparison) {
+              if (dialect === 'sqlite3') {
+                queryBuilder.whereRaw(`julianday(??) ${comparisonSymbol} julianday(?)`, [columnRef, valueForQuery.toISOString()])
+              } else {
+                queryBuilder.where(columnRef, comparisonSymbol, valueForQuery)
+              }
+            } else {
+              queryBuilder.where(columnRef, comparisonSymbol, valueForQuery)
+            }
+          }
 
           // Operating on an Association Resource Field
           if (isAssocClause) {
-            if (!assocModelName) {
-              throw new Error(`The query argument "${assocName}.${assocField}" is invalid as the association "${assocName}" does not exist for model "${modelName}"`)
-            }
-
-            if (assocConfig.type !== 'toOne') {
-              throw new Error(`The query argument "${assocName}.${assocField}" is invalid because the association "${assocName}" is not of type "toOne".`)
-            }
-
-            queryBuilder
-              .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
-              .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
-              .where(`${assocTableName}.${assocField}`, comparisonSymbol, bindingValue)
+            ensureAssociationJoin()
+            applyComparison(`${assocTableName}.${assocField}`)
 
           // Operating on a Main Resource Field
           } else {
-            queryBuilder.where(`${mainTableName}.${fieldName}`, comparisonSymbol, bindingValue)
+            applyComparison(`${mainTableName}.${fieldName}`)
           }
           break
         }

--- a/src/actions/bookshelf/utils/bookshelf-utils.js
+++ b/src/actions/bookshelf/utils/bookshelf-utils.js
@@ -110,7 +110,7 @@ export function loadRelationsToItemBase (itemData, loadDirect = {}, keepAsRelati
 // -----------------------------------------------------------------------------
 // Append a where clause to an existing query, per the provided input data.
 // -----------------------------------------------------------------------------
-export function appendWhereClause (joint, queryBuilder, modelName, fieldName, value) {
+export function appendWhereClause (joint, queryBuilder, modelName, fieldName, value, dataType) {
   // Load assets for query logic
   const mainTableName = joint.model[modelName].prototype.tableName
   // Required for association field queries
@@ -233,6 +233,65 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
 
           const valueForQuery = value[operator]
           queryBuilder.whereRaw(`?? NOT IN (${valueForQuery.map(() => '?').join(', ')})`, [`${mainTableName}.${fieldName}`, ...valueForQuery])
+          break
+        }
+
+        // OPERATORS: Comparison (lt, lte, gt, gte)
+        case ACTION.INPUT_FIELD_QUERY_LESS_THAN:
+        case ACTION.INPUT_FIELD_QUERY_LESS_THAN_OR_EQUAL:
+        case ACTION.INPUT_FIELD_QUERY_GREATER_THAN:
+        case ACTION.INPUT_FIELD_QUERY_GREATER_THAN_OR_EQUAL: {
+          if (debugAppendWhereClause) console.log(`[DEVING] Handling "${operator}" action on:`, value[operator])
+
+          // Load comparison symbol
+          const comparisonOperatorMap = {
+            [ACTION.INPUT_FIELD_QUERY_LESS_THAN]: '<',
+            [ACTION.INPUT_FIELD_QUERY_LESS_THAN_OR_EQUAL]: '<=',
+            [ACTION.INPUT_FIELD_QUERY_GREATER_THAN]: '>',
+            [ACTION.INPUT_FIELD_QUERY_GREATER_THAN_OR_EQUAL]: '>='
+          }
+          const comparisonSymbol = comparisonOperatorMap[operator]
+
+          // Only allow comparisons on Numbers or Dates
+          const supportedDataTypes = ['Number', 'Date']
+          if (!supportedDataTypes.includes(dataType)) {
+            throw new Error(`The "${operator}" operator is only supported for Number or Date fields.`)
+          }
+
+          const valueForQuery = value[operator]
+          if (valueForQuery === null || valueForQuery === undefined) {
+            throw new Error(`The "${operator}" operator requires a value.`)
+          }
+
+          if (dataType === 'Number' && (typeof valueForQuery !== 'number' || Number.isNaN(valueForQuery))) {
+            throw new Error(`The "${operator}" operator requires a valid Number value.`)
+          }
+
+          if (dataType === 'Date' && (!(valueForQuery instanceof Date) || Number.isNaN(valueForQuery.valueOf()))) {
+            throw new Error(`The "${operator}" operator requires a valid Date value.`)
+          }
+
+          const bindingValue = (dataType === 'Date') ? valueForQuery.toISOString() : valueForQuery
+
+          // Operating on an Association Resource Field
+          if (isAssocClause) {
+            if (!assocModelName) {
+              throw new Error(`The query argument "${assocName}.${assocField}" is invalid as the association "${assocName}" does not exist for model "${modelName}"`)
+            }
+
+            if (assocConfig.type !== 'toOne') {
+              throw new Error(`The query argument "${assocName}.${assocField}" is invalid because the association "${assocName}" is not of type "toOne".`)
+            }
+
+            queryBuilder
+              .leftJoin(assocTableName, `${mainTableName}.${assocPathInfo.sourceField}`, `${assocTableName}.${assocPathInfo.targetField}`)
+              .select(`${mainTableName}.*`, `${assocTableName}.${assocField}`)
+              .where(`${assocTableName}.${assocField}`, comparisonSymbol, bindingValue)
+
+          // Operating on a Main Resource Field
+          } else {
+            queryBuilder.where(`${mainTableName}.${fieldName}`, comparisonSymbol, bindingValue)
+          }
           break
         }
 

--- a/test/db/bookshelf/seeds/project_contributors/001_project_contributors.js
+++ b/test/db/bookshelf/seeds/project_contributors/001_project_contributors.js
@@ -1,0 +1,91 @@
+const moment = require('moment')
+
+const tableName = 'project_contributors_ref'
+
+const seeds = [
+  // -------------------------
+  // Mega-Seed Mini-Sythesizer
+  // -------------------------
+  {
+    id: 1,
+    project_id: 1,
+    user_id: 6, // ricksanchez
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2016-07-30T11:20+08:00',
+    finished_at: '2018-08-02T21:30+08:00'
+  },
+
+  // -------------------------
+  // Turn Myself into a Pickle
+  // -------------------------
+  {
+    id: 2,
+    project_id: 2,
+    user_id: 6, // ricksanchez
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2015-01-01',
+    finished_at: '2015-12-08'
+  },
+  {
+    id: 3,
+    project_id: 2,
+    user_id: 7, // mortysmith
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2015-09-01',
+    finished_at: '2015-11-30'
+  },
+
+  // ----------------
+  // Blue Dreamsicles
+  // ----------------
+  {
+    id: 4,
+    project_id: 4,
+    user_id: 4, // the_manic_edge
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2018-01-03',
+    finished_at: '2020-09-29'
+  },
+
+  // -------------------
+  // Doppelgänger Finder
+  // -------------------
+  {
+    id: 5,
+    project_id: 3,
+    user_id: 4, // the_manic_edge
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2020-03-01',
+    finished_at: null
+  },
+  {
+    id: 6,
+    project_id: 3,
+    user_id: 5, // segmented
+    contributor_role: null,
+    is_active_contributor: true,
+    started_at: '2020-03-14',
+    finished_at: null
+  }
+]
+
+exports.seed = function seed (knex) {
+  return knex(tableName).del().then(() => {
+    const time = moment().utc()
+
+    return Promise.all(seeds.map((data) => {
+      const timestamp = time.add(5, 'minutes').format()
+
+      return knex(tableName).insert({
+        ...data,
+        created_at: timestamp,
+        updated_at: timestamp
+      })
+    }))
+  })
+}

--- a/test/functional/actions/bookshelf/crud_getItem.spec.js
+++ b/test/functional/actions/bookshelf/crud_getItem.spec.js
@@ -604,7 +604,7 @@ describe('CRUD ACTIONS [bookshelf]', () => {
     })
 
     describe('using advanced queries with object notation on the input value:', async () => {
-      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS} operator (for case sensitive)`, async () => {
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS} property (for case sensitive)`, async () => {
         const specUser = {
           modelName: 'User',
           fields: [

--- a/test/functional/actions/bookshelf/crud_getItems.spec.js
+++ b/test/functional/actions/bookshelf/crud_getItems.spec.js
@@ -758,8 +758,6 @@ describe('ACTION: getItems [bookshelf]', () => {
       })
     })
 
-    // TODO - Test multiple operators on a single query !!!
-
     describe('using advanced queries with object notation on the input value:', async () => {
       it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS} operator (for case sensitive)`, async () => {
         const specUser = {
@@ -859,7 +857,7 @@ describe('ACTION: getItems [bookshelf]', () => {
         expect(getUsersFilteredByContains.data[1].username).toEqual('admin')
       })
 
-      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS_INSENSITIVE} property (for case insensitive)`, async () => {
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS_INSENSITIVE} operator (for case insensitive)`, async () => {
         const specUser = {
           modelName: 'User',
           fields: [
@@ -884,7 +882,7 @@ describe('ACTION: getItems [bookshelf]', () => {
         expect(getUsersFilteredByCI.data[1].display_name).toEqual('Segmented')
       })
 
-      it(`should support the ${ACTION.INPUT_FIELD_QUERY_EXCLUDES} property`, async () => {
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_EXCLUDES} operator`, async () => {
         // User
         const specUser = {
           modelName: 'User',
@@ -932,6 +930,116 @@ describe('ACTION: getItems [bookshelf]', () => {
         expect(getProjectsFiltered.data[1].alias).toEqual('project-001')
         expect(getProjectsFiltered.data[2].alias).toEqual('project-006')
         expect(getProjectsFiltered.data[3].alias).toEqual('project-010')
+      })
+
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_LESS_THAN} operator`, async () => {
+        const specProject = {
+          modelName: 'Project',
+          fields: [
+            { name: 'name', type: 'String' },
+            { name: 'status_code', type: 'Number' },
+            { name: 'started_at', type: 'Date' },
+            { name: 'finished_at', type: 'Date' },
+            { name: 'created_at', type: 'Date' }
+          ],
+          defaultOrderBy: 'alias'
+        }
+
+        const projectsFilteredByLessThanNumber = {
+          fields: {
+            status_code: {
+              lt: 4
+            }
+          }
+        }
+
+        const projectsFilteredByLessThanDate1 = {
+          fields: {
+            finished_at: {
+              lt: new Date('2016-09-01')
+            }
+          },
+          orderBy: '-alias'
+        }
+
+        const projectsFilteredByLessThanDate2 = {
+          fields: {
+            finished_at: {
+              lt: new Date('2017-08-01')
+            }
+          },
+          orderBy: '-alias'
+        }
+
+        const getProjectsLessThanNumber = await projectApp.getItems(specProject, projectsFilteredByLessThanNumber, 'flat')
+        // console.log('[DEVING] getProjectsLessThanNumber.data:', getProjectsLessThanNumber.data)
+        expect(getProjectsLessThanNumber.data).to.have.length(3)
+        expect(getProjectsLessThanNumber.data[0].status_code).toEqual(3)
+        expect(getProjectsLessThanNumber.data[0].alias).toEqual('blue-dreamsicles')
+
+        const getProjectsLessThanDate1 = await projectApp.getItems(specProject, projectsFilteredByLessThanDate1, 'flat')
+        // console.log('[DEVING] getProjectsLessThanDate1.data:', getProjectsLessThanDate1.data)
+        expect(getProjectsLessThanDate1.data).to.have.length(1)
+        expect(getProjectsLessThanDate1.data[0].alias).toEqual('mega-seed-mini-sythesizer')
+
+        const getProjectsLessThanDate2 = await projectApp.getItems(specProject, projectsFilteredByLessThanDate2, 'flat')
+        // console.log('[DEVING] getProjectsLessThanDate2.data:', getProjectsLessThanDate2.data)
+        expect(getProjectsLessThanDate2.data).to.have.length(4)
+        expect(getProjectsLessThanDate2.data[0].alias).toEqual('project-005')
+      })
+
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_GREATER_THAN} operator`, async () => {
+        const specProject = {
+          modelName: 'Project',
+          fields: [
+            { name: 'name', type: 'String' },
+            { name: 'status_code', type: 'Number' },
+            { name: 'started_at', type: 'Date' },
+            { name: 'finished_at', type: 'Date' }
+          ],
+          defaultOrderBy: 'alias'
+        }
+
+        const projectsFilteredByGreaterThanDate = {
+          fields: {
+            finished_at: {
+              gt: new Date('2017-09-22')
+            }
+          },
+          orderBy: '-alias'
+        }
+
+        const getProjectsGreaterThanDate = await projectApp.getItems(specProject, projectsFilteredByGreaterThanDate, 'flat')
+        expect(getProjectsGreaterThanDate.data).to.have.length(2)
+        expect(getProjectsGreaterThanDate.data[0].alias).toEqual('project-009')
+      })
+
+      it('should support multiple operators on a single query', async () => {
+        const specProject = {
+          modelName: 'Project',
+          fields: [
+            { name: 'name', type: 'String' },
+            { name: 'status_code', type: 'Number' },
+            { name: 'started_at', type: 'Date' },
+            { name: 'finished_at', type: 'Date' }
+          ],
+          defaultOrderBy: 'alias'
+        }
+
+        const projectsFilteredByDateRange = {
+          fields: {
+            finished_at: {
+              gt: new Date('2017-09-22'),
+              lt: new Date('2017-11-01')
+            }
+          },
+          orderBy: '-alias'
+        }
+
+        const getProjectsInDateRange = await projectApp.getItems(specProject, projectsFilteredByDateRange, 'flat')
+        // console.log('[DEVING] getProjectsInDateRange.data:', getProjectsInDateRange.data)
+        expect(getProjectsInDateRange.data).to.have.length(1)
+        expect(getProjectsInDateRange.data[0].alias).toEqual('project-009')
       })
     })
 

--- a/test/functional/actions/bookshelf/crud_getItems.spec.js
+++ b/test/functional/actions/bookshelf/crud_getItems.spec.js
@@ -70,7 +70,7 @@ describe('ACTION: getItems [bookshelf]', () => {
   // getItems
   // ---------------------------------------------------------------------------
   describe('getItems', () => {
-    beforeEach(() => resetDB(['users', 'roles', 'profiles', 'projects']))
+    beforeEach(() => resetDB(['users', 'roles', 'profiles', 'projects', 'project_contributors']))
 
     it('should return all rows according to the provided spec and input', async () => {
       // ----
@@ -984,8 +984,51 @@ describe('ACTION: getItems [bookshelf]', () => {
 
         const getProjectsLessThanDate2 = await projectApp.getItems(specProject, projectsFilteredByLessThanDate2, 'flat')
         // console.log('[DEVING] getProjectsLessThanDate2.data:', getProjectsLessThanDate2.data)
-        expect(getProjectsLessThanDate2.data).to.have.length(4)
-        expect(getProjectsLessThanDate2.data[0].alias).toEqual('project-005')
+        expect(getProjectsLessThanDate2.data).to.have.length(3)
+        expect(getProjectsLessThanDate2.data[0].alias).toEqual('project-002')
+      })
+
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_LESS_THAN} operator with an association field`, async () => {
+        const specProjectContributor = {
+          modelName: 'ProjectContributor',
+          fields: [
+            { name: 'started_at', type: 'Date' },
+            { name: 'finished_at', type: 'Date' },
+            { name: 'project.started_at', type: 'Date' },
+            { name: 'project.finished_at', type: 'Date' }
+          ],
+          defaultOrderBy: 'user_id'
+        }
+
+        const projectsLessThanDate = {
+          fields: {
+            'project.started_at': {
+              lt: new Date('2017-03-11')
+            }
+          }
+        }
+
+        const projectsDateRange = {
+          fields: {
+            'project.finished_at': {
+              gte: new Date('2017-03-29'),
+              lt: new Date('2017-10-09')
+            }
+          },
+          orderBy: '-user_id'
+        }
+
+        const getContributorRefsForProjectLessThan = await projectApp.getItems(specProjectContributor, projectsLessThanDate, 'flat')
+        // console.log('[DEVING] getContributorRefsForProjectLessThan.data:', getContributorRefsForProjectLessThan.data)
+        expect(getContributorRefsForProjectLessThan.data).to.have.length(3)
+        expect(getContributorRefsForProjectLessThan.data[0].project_id).toEqual(3)
+        expect(getContributorRefsForProjectLessThan.data[0].user_id).toEqual(4)
+
+        const getContributorRefsForProjectDateRange = await projectApp.getItems(specProjectContributor, projectsDateRange, 'flat')
+        // console.log('[DEVING] getContributorRefsForProjectDateRange.data:', getContributorRefsForProjectDateRange.data)
+        expect(getContributorRefsForProjectDateRange.data).to.have.length(2)
+        expect(getContributorRefsForProjectDateRange.data[0].project_id).toEqual(3)
+        expect(getContributorRefsForProjectDateRange.data[0].user_id).toEqual(5)
       })
 
       it(`should support the ${ACTION.INPUT_FIELD_QUERY_GREATER_THAN} operator`, async () => {
@@ -1014,7 +1057,7 @@ describe('ACTION: getItems [bookshelf]', () => {
         expect(getProjectsGreaterThanDate.data[0].alias).toEqual('project-009')
       })
 
-      it('should support multiple operators on a single query', async () => {
+      it('should support multiple comparison operators on a single query', async () => {
         const specProject = {
           modelName: 'Project',
           fields: [

--- a/test/functional/actions/bookshelf/crud_updateItem.spec.js
+++ b/test/functional/actions/bookshelf/crud_updateItem.spec.js
@@ -271,7 +271,7 @@ describe('CRUD ACTIONS [bookshelf]', () => {
     })
 
     describe('using advanced queries with object notation on the input value:', async () => {
-      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS} operator (for case sensitive)`, async () => {
+      it(`should support the ${ACTION.INPUT_FIELD_QUERY_CONTAINS} property (for case sensitive)`, async () => {
         const specProject = {
           modelName: 'Project',
           fields: [

--- a/test/scenarios/project-app/model-config.js
+++ b/test/scenarios/project-app/model-config.js
@@ -100,6 +100,10 @@ module.exports = [
       contributor: {
         type: 'toOne',
         path: 'user_id => User.id'
+      },
+      project: {
+        type: 'toOne',
+        path: 'project_id => Project.id'
       }
     }
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds lt/lte/gt/gte advanced query support for Numbers/Dates (including association fields), with proper type casting/validation, new seeds/tests, and version bump.
> 
> - **Query Engine (Bookshelf)**:
>   - Implement `lt`/`lte`/`gt`/`gte` operators in `bookshelf-utils.appendWhereClause()` with validation for `Number`/`Date`, SQLite `julianday` handling, and reusable association join helper; supports association field comparisons.
>   - `getItems` now passes field `type` to `appendWhereClause()`.
> - **Utilities**:
>   - `prepareFieldData()` casts values inside advanced query objects (except `JSON`).
>   - `castValue()` adds `Date` support.
> - **Tests & Fixtures**:
>   - Add functional tests for comparison operators (including association fields and combined ranges).
>   - Seed `project_contributors_ref` and update `resetDB` lists.
>   - Extend `project-app` model-config with `ProjectContributor.project` toOne association.
> - **Docs & Meta**:
>   - Update `TODO.md` (backlog and examples wording).
>   - Bump `package.json` version to `0.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb3f0ad77a166f3b5c9ae7bb4fce1ea10ce469ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->