### PR TITLE
Feat/date comparison for infinity

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,8 @@
 
 ## Backlog
 
+* Support `infinity` with date comparison logic.
+
 * Support advanced comparison logic on toMany associations.
 
 * `ActionUtils.prepareFieldData()` could populate the default value, so that in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joint-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A server-side toolset for building data layers and RESTful endpoints with NodeJS",
   "author": "|M| <manicprone@gmail.com>",
   "license": "MIT",

--- a/src/actions/bookshelf/utils/bookshelf-utils.js
+++ b/src/actions/bookshelf/utils/bookshelf-utils.js
@@ -285,15 +285,21 @@ export function appendWhereClause (joint, queryBuilder, modelName, fieldName, va
 
           const isDateComparison = dataType === 'Date'
           const applyComparison = (columnRef) => {
-            if (isDateComparison) {
-              if (dialect === 'sqlite3') {
-                queryBuilder.whereRaw(`julianday(??) ${comparisonSymbol} julianday(?)`, [columnRef, valueForQuery.toISOString()])
+            queryBuilder.where(function comparisonClause () {
+              if (isDateComparison) {
+                if (dialect === 'sqlite3') {
+                  this.whereRaw(`julianday(??) ${comparisonSymbol} julianday(?)`, [columnRef, valueForQuery.toISOString()])
+                } else {
+                  this.where(columnRef, comparisonSymbol, valueForQuery)
+                }
               } else {
-                queryBuilder.where(columnRef, comparisonSymbol, valueForQuery)
+                this.where(columnRef, comparisonSymbol, valueForQuery)
               }
-            } else {
-              queryBuilder.where(columnRef, comparisonSymbol, valueForQuery)
-            }
+
+              if (isDateComparison && dialect === 'sqlite3') {
+                this.orWhereRaw('LOWER(??) = ?', [columnRef, 'infinity'])
+              }
+            })
           }
 
           // Operating on an Association Resource Field

--- a/test/db/bookshelf/seeds/projects/002_projects.js
+++ b/test/db/bookshelf/seeds/projects/002_projects.js
@@ -148,7 +148,7 @@ const seeds = [
     is_internal: false,
     status_code: 4,
     started_at: '2017-08-22',
-    finished_at: null,
+    finished_at: 'infinity',
     created_by: null
   },
   {

--- a/test/functional/actions/bookshelf/crud_getItems.spec.js
+++ b/test/functional/actions/bookshelf/crud_getItems.spec.js
@@ -953,6 +953,7 @@ describe('ACTION: getItems [bookshelf]', () => {
           }
         }
 
+        // NOTE - This test includes a use case with 'infinity'
         const projectsFilteredByLessThanDate1 = {
           fields: {
             finished_at: {
@@ -962,13 +963,13 @@ describe('ACTION: getItems [bookshelf]', () => {
           orderBy: '-alias'
         }
 
+        // NOTE - This test includes a use case with 'infinity'
         const projectsFilteredByLessThanDate2 = {
           fields: {
             finished_at: {
               lt: new Date('2017-08-01')
             }
-          },
-          orderBy: '-alias'
+          }
         }
 
         const getProjectsLessThanNumber = await projectApp.getItems(specProject, projectsFilteredByLessThanNumber, 'flat')
@@ -979,13 +980,14 @@ describe('ACTION: getItems [bookshelf]', () => {
 
         const getProjectsLessThanDate1 = await projectApp.getItems(specProject, projectsFilteredByLessThanDate1, 'flat')
         // console.log('[DEVING] getProjectsLessThanDate1.data:', getProjectsLessThanDate1.data)
-        expect(getProjectsLessThanDate1.data).to.have.length(1)
-        expect(getProjectsLessThanDate1.data[0].alias).toEqual('mega-seed-mini-sythesizer')
+        expect(getProjectsLessThanDate1.data).to.have.length(2)
+        expect(getProjectsLessThanDate1.data[0].alias).toEqual('project-006')
+        expect(getProjectsLessThanDate1.data[0].finished_at).toEqual('infinity')
 
         const getProjectsLessThanDate2 = await projectApp.getItems(specProject, projectsFilteredByLessThanDate2, 'flat')
         // console.log('[DEVING] getProjectsLessThanDate2.data:', getProjectsLessThanDate2.data)
-        expect(getProjectsLessThanDate2.data).to.have.length(3)
-        expect(getProjectsLessThanDate2.data[0].alias).toEqual('project-002')
+        expect(getProjectsLessThanDate2.data).to.have.length(4)
+        expect(getProjectsLessThanDate2.data[0].alias).toEqual('doppelganger-finder')
       })
 
       it(`should support the ${ACTION.INPUT_FIELD_QUERY_LESS_THAN} operator with an association field`, async () => {
@@ -1040,21 +1042,24 @@ describe('ACTION: getItems [bookshelf]', () => {
             { name: 'started_at', type: 'Date' },
             { name: 'finished_at', type: 'Date' }
           ],
-          defaultOrderBy: 'alias'
+          defaultOrderBy: '-alias'
         }
 
+        // NOTE - This test includes a use case with 'infinity'
         const projectsFilteredByGreaterThanDate = {
           fields: {
             finished_at: {
               gt: new Date('2017-09-22')
             }
           },
-          orderBy: '-alias'
+          orderBy: 'alias'
         }
 
         const getProjectsGreaterThanDate = await projectApp.getItems(specProject, projectsFilteredByGreaterThanDate, 'flat')
-        expect(getProjectsGreaterThanDate.data).to.have.length(2)
-        expect(getProjectsGreaterThanDate.data[0].alias).toEqual('project-009')
+        // console.log('[DEVING] getProjectsGreaterThanDate.data:', getProjectsGreaterThanDate.data)
+        expect(getProjectsGreaterThanDate.data).to.have.length(3)
+        expect(getProjectsGreaterThanDate.data[0].alias).toEqual('project-006')
+        expect(getProjectsGreaterThanDate.data[0].finished_at).toEqual('infinity')
       })
 
       it('should support multiple comparison operators on a single query', async () => {
@@ -1066,23 +1071,24 @@ describe('ACTION: getItems [bookshelf]', () => {
             { name: 'started_at', type: 'Date' },
             { name: 'finished_at', type: 'Date' }
           ],
-          defaultOrderBy: 'alias'
+          defaultOrderBy: '-alias'
         }
 
+        // NOTE - This test includes a use case with 'infinity'
         const projectsFilteredByDateRange = {
           fields: {
             finished_at: {
               gt: new Date('2017-09-22'),
               lt: new Date('2017-11-01')
             }
-          },
-          orderBy: '-alias'
+          }
         }
 
         const getProjectsInDateRange = await projectApp.getItems(specProject, projectsFilteredByDateRange, 'flat')
         // console.log('[DEVING] getProjectsInDateRange.data:', getProjectsInDateRange.data)
-        expect(getProjectsInDateRange.data).to.have.length(1)
+        expect(getProjectsInDateRange.data).to.have.length(2)
         expect(getProjectsInDateRange.data[0].alias).toEqual('project-009')
+        expect(getProjectsInDateRange.data[1].finished_at).toEqual('infinity')
       })
     })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds sqlite3 date comparison support for `infinity`, updates seeds/tests accordingly, and bumps version to 0.1.2.
> 
> - **Bookshelf utils (`src/actions/bookshelf/utils/bookshelf-utils.js`)**:
>   - Enhances date comparison operators (`lt`, `lte`, `gt`, `gte`) to:
>     - Use a grouped where-clause; for sqlite3 compare via `julianday(...)`.
>     - Treat `LOWER(column) = 'infinity'` as a match for date comparisons in sqlite3.
>   - Applies logic for both main and association fields.
> - **Tests/Seeds**:
>   - Set `finished_at: 'infinity'` for `projects` seed id 10.
>   - Update functional tests to include and assert `infinity` cases; adjust expected counts/ordering and some `defaultOrderBy` values.
> - **Package**: bump version to `0.1.2` in `package.json`.
> - **Docs**: add backlog note for supporting `infinity` with date comparisons in `TODO.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38001ecc64dc8e5668930711013a48dd0ea2c259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->